### PR TITLE
Enhancement: add parametrized anatomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ $ pip install pytest-ayon
 ```
 or
 ```shell
-$ poetry add --dev pytest-ayon
+$ uv add pytest-ayon
 ```
 
 ## Usage
@@ -19,3 +19,17 @@ In your test, import fixtures and helper functions from `pytest_ayon` module.
 ```python
 from pytest_ayon import ayon_fixture, ayon_tool
 ```
+
+`project` is now configurable through fixtures/indirect parameters:
+
+- `project_anatomy_preset_name` (default `"__primary__"`)
+- `project_anatomy_fallback_presets` (default `( "__builtin__", )`)
+- `project_anatomy_overrides`
+- `project_params`
+
+Anatomy is resolved from server presets using:
+
+- `GET /api/anatomy/presets/__primary__`
+- fallback `GET /api/anatomy/presets/__builtin__`
+
+If neither preset is available, a built-in local anatomy fallback is used.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,12 @@ classifiers = [
     "Topic :: Software Development :: Testing",
     "Framework :: Pytest",
 ]
-requires-python = ">=3.9"
+requires-python = "==3.11.6"
 dependencies = [
     "pytest",
     "ayon-python-api",
-    "requests ~= 2.17"
+    "requests ~= 2.17",
+    "ruff>=0.15.7",
 ]
 
 [project.entry-points.pytest11]
@@ -31,10 +32,9 @@ ayon = "pytest_ayon.plugin"
 
 [project.optional-dependencies]
 dev = [
-    "ruff ~= 0.14.1",
+    "ruff ~= 0.15.7",
     "pre-commit",
     "codespell",
-    "pydantic~=1.9",
     "pytest-cov",
     "pytest-print",
     "mypy",
@@ -109,6 +109,7 @@ ignore = [
     "CPY001",  # missing copyright header
     "UP045",
     "S101",    # use of assert
+    "AST100",  # asserts only in tests
 ]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/pytest_ayon/__init__.py
+++ b/pytest_ayon/__init__.py
@@ -3,6 +3,11 @@ from .addons import build_addon_package, imprint_test_version, installed_addon
 from .plugin import (
                      ProjectInfo,
                      addon_version,
+                     project_anatomy,
+                     project_anatomy_fallback_presets,
+                     project_anatomy_overrides,
+                     project_anatomy_preset_name,
+                     project_params,
                      ayon_connection_env,
                      ayon_server_session,
                      base_dir,
@@ -19,6 +24,11 @@ __all__ = [
                      "build_addon_package",
                      "imprint_test_version",
                      "installed_addon",
+                     "project_anatomy",
+                     "project_anatomy_fallback_presets",
+                     "project_anatomy_overrides",
+                     "project_anatomy_preset_name",
+                     "project_params",
                      "project",
                      "project_root_path",
 ]

--- a/pytest_ayon/plugin.py
+++ b/pytest_ayon/plugin.py
@@ -123,15 +123,13 @@ def _default_project_anatomy() -> dict[str, Any]:
             "hero": [
                 {
                     "name": "default",
-                    "directory": (
-                        "{root[work]}/{project[name]}/{hierarchy}/"
-                        "{folder[name]}/publish/{product[type]}/"
-                        "{product[name]}/hero"
-                    ),
-                    "file": (
-                        "{project[code]}_{folder[name]}_"
-                        "{task[name]}_hero<_{comment}>.{ext}"
-                    )
+                     "directory": "{root[work]}/{project[name]}/"
+                                     "{hierarchy}/{folder[name]}/publish/"
+                                     "{product[type]}"
+                                     "/{product[name]}/hero",
+                    "file": "{project[code]}_{folder[name]}_"
+                                "{product[name]}_hero<_{output}>"
+                                "<.{@frame}><_{udim}>.{ext}"
                 }
             ],
         },

--- a/pytest_ayon/plugin.py
+++ b/pytest_ayon/plugin.py
@@ -12,11 +12,12 @@ TODO (antirotor):
 from __future__ import annotations
 
 import contextlib
+import copy
 import os
 import random
 import secrets
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generator, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, Callable, Generator, List, NamedTuple, Optional
 
 import pytest
 import requests
@@ -73,6 +74,190 @@ class ProjectInfo:
     version_entity: Optional[dict]
     representations: Optional[list[IdNamePair]]
     links: Optional[list[str]]
+
+
+def _default_project_anatomy() -> dict[str, Any]:
+    """Default anatomy used when server presets are unavailable."""
+    return {
+        "roots": [
+            {
+                "name": "work",
+                "windows": "C:/projects",
+                "linux": "/mnt/share/projects",
+                "darwin": "/Volumes/projects"
+            }
+        ],
+        "templates": {
+            "version_padding": 3,
+            "version": "v{version:0>{@version_padding}}",
+            "frame_padding": 4,
+            "frame": "{frame:0>{@frame_padding}}",
+            "work": [
+                {
+                    "name": "default",
+                    "directory": (
+                        "{root[work]}/{project[name]}/{hierarchy}/"
+                        "{folder[name]}/work/{task[name]}"
+                    ),
+                    "file": (
+                        "{project[code]}_{folder[name]}_{task[name]}_"
+                        "{@version}<_{comment}>.{ext}"
+                    )
+                }
+            ],
+            "publish": [
+                {
+                    "name": "default",
+                    "directory": (
+                        "{root[work]}/{project[name]}/{hierarchy}/"
+                        "{folder[name]}/publish/{product[type]}/"
+                        "{product[name]}/v{version:0>3}"  # noqa: RUF027
+                    ),
+                    "file": (
+                        "{project[code]}_{folder[name]}_{product[name]}"
+                        "_v{version:0>3}<_{output}><.{frame:0>4}>"
+                        "<_{udim}>.{ext}"
+                    )
+                }
+            ],
+            "hero": [
+                {
+                    "name": "default",
+                    "directory": (
+                        "{root[work]}/{project[name]}/{hierarchy}/"
+                        "{folder[name]}/publish/{product[type]}/"
+                        "{product[name]}/hero"
+                    ),
+                    "file": (
+                        "{project[code]}_{folder[name]}_"
+                        "{task[name]}_hero<_{comment}>.{ext}"
+                    )
+                }
+            ],
+        },
+        "attributes": {
+            "fps": 25,
+            "resolutionWidth": 1920,
+            "resolutionHeight": 1080,
+            "pixelAspect": 1,
+            "clipIn": 1,
+            "clipOut": 1,
+            "frameStart": 1001,
+            "frameEnd": 1050,
+            "handleStart": 0,
+            "handleEnd": 0,
+            "startDate": "2021-01-01T00:00:00+00:00",
+            "endDate": "2021-01-01T00:00:00+00:00",
+            "description": "A very nice entity",
+            "applications": [],
+            "tools": []
+        },
+        "folder_types": [
+            {
+                "name": "Asset",
+                "icon": "folder",
+                "original_name": "Asset"
+            }
+        ],
+        "task_types": [
+            {
+                "name": "rendering",
+                "shortName": "rendering",
+                "icon": "",
+                "original_name": "rendering"
+            }
+        ],
+        "linkTypes": [
+            {
+                "name": "relationship|representation|representation",
+                "link_type": "relationship",
+                "input_type": "representation",
+                "output_type": "representation",
+                "data": {
+                    "color": "#73149F",
+                }
+            }
+        ],
+        "statuses": [
+            {
+                "name": "not_started",
+                "shortName": "not_started",
+                "state": "not_started",
+                "icon": "",
+                "color": "#cacaca",
+                "original_name": "string"
+            }
+        ]
+    }
+
+
+def _merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge dictionaries."""
+    merged = copy.deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _merge_dicts(merged[key], value)
+            continue
+        merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _extract_anatomy_from_preset(data: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """Extract anatomy payload from possible preset response formats."""
+    candidates: list[Any] = [
+        data.get("anatomy"),
+        data.get("data", {}).get("anatomy") if isinstance(data.get("data"), dict) else None,
+        data.get("data"),
+        data,
+    ]
+    for candidate in candidates:
+        if isinstance(candidate, dict) and "roots" in candidate and "templates" in candidate:
+            return candidate
+    return None
+
+
+def _fetch_anatomy_preset(
+        session: requests.Session,
+        server_url: str,
+        preset_name: str) -> Optional[dict[str, Any]]:
+    """Fetch anatomy preset from server and return anatomy data."""
+    response = session.get(f"{server_url}/api/anatomy/presets/{preset_name}")
+    if response.status_code != STATUS_OK:
+        return None
+    anatomy = _extract_anatomy_from_preset(response.json())
+    if anatomy is None:
+        return None
+    return copy.deepcopy(anatomy)
+
+
+def _first_named_item_name(items: Any) -> Optional[str]:
+    """Return first `name` field from a list of dictionaries."""
+    if not isinstance(items, list) or not items:
+        return None
+    item = items[0]
+    if not isinstance(item, dict):
+        return None
+    name = item.get("name")
+    return name if isinstance(name, str) else None
+
+
+def _first_work_root(anatomy: dict[str, Any]) -> dict[str, str]:
+    """Return first available root dictionary."""
+    roots = anatomy.get("roots")
+    if isinstance(roots, list):
+        for root in roots:
+            if isinstance(root, dict):
+                return root
+    return {"name": "work", "windows": "C:/projects"}
+
+
+def _work_root_path(root: dict[str, str]) -> str:
+    """Resolve work root path for representation context."""
+    for platform_key in ("windows", "linux", "darwin"):
+        value = root.get(platform_key)
+        if isinstance(value, str) and value:
+            return value
+    return "C:/projects"
 
 
 @pytest.fixture(scope="session")
@@ -160,10 +345,83 @@ def addon_version(project_root_path: Path) -> NamedTuple:
 
 
 @pytest.fixture
+def project_anatomy_preset_name(request: pytest.FixtureRequest) -> str:
+    """Preferred server anatomy preset name.
+
+    Can be overridden via indirect parametrization of this fixture.
+    """
+    return getattr(request, "param", "__primary__")
+
+
+@pytest.fixture
+def project_anatomy_fallback_presets() -> tuple[str, ...]:
+    """Fallback presets tried if preferred anatomy preset is not available."""
+    return ("__builtin__",)
+
+
+@pytest.fixture
+def project_anatomy_overrides() -> dict[str, Any]:
+    """Optional anatomy override data merged on top of resolved anatomy."""
+    return {}
+
+
+@pytest.fixture
+def project_anatomy(
+        ayon_connection_env: tuple[str, str],
+        ayon_server_session: requests.Session,
+        project_anatomy_preset_name: str,
+        project_anatomy_fallback_presets: tuple[str, ...],
+        project_anatomy_overrides: dict[str, Any]) -> dict[str, Any]:
+    """Resolve anatomy from presets, with fallback to built-in defaults."""
+    server_url, _ = ayon_connection_env
+    preset_names: list[str] = [project_anatomy_preset_name, *project_anatomy_fallback_presets]
+    seen: set[str] = set()
+    anatomy: Optional[dict[str, Any]] = None
+
+    for preset_name in preset_names:
+        if preset_name in seen:
+            continue
+        seen.add(preset_name)
+        anatomy = _fetch_anatomy_preset(ayon_server_session, server_url, preset_name)
+        if anatomy is not None:
+            break
+
+    if anatomy is None:
+        anatomy = _default_project_anatomy()
+
+    if project_anatomy_overrides:
+        anatomy = _merge_dicts(anatomy, project_anatomy_overrides)
+
+    return anatomy
+
+
+@pytest.fixture
+def project_params(request: pytest.FixtureRequest) -> dict[str, Any]:
+    """Project fixture defaults, overridable via indirect parametrization."""
+    defaults = {
+        "product_name": "renderMain",
+        "product_type": "render",
+        "version": 1,
+        "task_name": "rendering",
+        "task_type": "rendering",
+        "folder_type": "Asset",
+        "representation_count": 4,
+        "representation_name_prefix": "exr",
+        "frame_start": 1001,
+        "frame_end_min": 1020,
+        "frame_end_max": 1200,
+        "link_pairs": [(0, 1, "relationship_2"), (2, 3, "relationship_1")],
+        "library": False,
+    }
+    return {**defaults, **getattr(request, "param", {})}
+
+
+@pytest.fixture
 def project(  # noqa: PLR0914, PLR0915
-        printer,  # noqa: ANN001 (fixture)
-        ayon_connection_env: tuple[str, str]
-) -> Generator[ProjectInfo, None, None]:
+        printer: Callable[[Any], None],
+        ayon_connection_env: tuple[str, str],
+        project_anatomy: dict[str, Any],
+        project_params: dict[str, Any]) -> Generator[ProjectInfo, None, None]:
     """Set up a project with some data and yield the project info.
 
     This will create a project with a folder, a task, a product, a version,
@@ -186,9 +444,20 @@ def project(  # noqa: PLR0914, PLR0915
     project_name = f"{token}_test_project"
     project_code = f"TP_{token[:3]}"
     folder_name = f"t_folder_{secrets.token_hex(3)}"
-    product_name = "renderMain"
-    version = 1
-    task_name = "rendering"
+    product_name = project_params["product_name"]
+    product_type = project_params["product_type"]
+    version = project_params["version"]
+
+    task_type = project_params["task_type"]
+    anatomy_task_type = _first_named_item_name(project_anatomy.get("task_types"))
+    if anatomy_task_type:
+        task_type = anatomy_task_type
+    task_name = project_params["task_name"] or task_type
+
+    folder_type = project_params["folder_type"]
+    anatomy_folder_type = _first_named_item_name(project_anatomy.get("folder_types"))
+    if anatomy_folder_type:
+        folder_type = anatomy_folder_type
 
     printer(f"creating project {project_name}...")
     session = requests.Session()
@@ -197,116 +466,8 @@ def project(  # noqa: PLR0914, PLR0915
     project_data = {
         "name": project_name,
         "code": project_code,
-        "anatomy": {
-            "roots": [
-                {
-                    "name": "work",
-                    "windows": "C:/projects",
-                    "linux": "/mnt/share/projects",
-                    "darwin": "/Volumes/projects"
-                }
-            ],
-            "templates": {
-                "version_padding": 3,
-                "version": "v{version:0>{@version_padding}}",
-                "frame_padding": 4,
-                "frame": "{frame:0>{@frame_padding}}",
-                "work": [
-                    {
-                        "name": "default",
-                        "directory": (
-                            "{root[work]}/{project[name]}/{hierarchy}/"
-                            "{folder[name]}/work/{task[name]}"),
-                        "file": (
-                            "{project[code]}_{folder[name]}_{task[name]}_"
-                            "{@version}<_{comment}>.{ext}")
-                    }
-                ],
-                "publish": [
-                    {
-                        "name": "default",
-                        "directory": (
-                            "{root[work]}/{project[name]}/{hierarchy}/"
-                            "{folder[name]}/publish/{product[type]}/"
-                            "{product[name]}/v{version:0>3}"  # noqa: RUF027
-                        ),
-                        "file": (
-                            "{project[code]}_{folder[name]}_{product[name]}"
-                            "_v{version:0>3}<_{output}><.{frame:0>4}>"
-                            "<_{udim}>.{ext}"
-                        )
-                    }
-                ],
-                "hero": [
-                    {
-                        "name": "default",
-                        "directory": (
-                            "{root[work]}/{project[name]}/{hierarchy}/"
-                            "{folder[name]}/publish/{product[type]}/"
-                            "{product[name]}/hero"
-                        ),
-                        "file": (
-                            "{project[code]}_{folder[name]}_"
-                            "{task[name]}_hero<_{comment}>.{ext}"
-                        )
-                    }
-                ],
-            },
-            "attributes": {
-                "fps": 25,
-                "resolutionWidth": 1920,
-                "resolutionHeight": 1080,
-                "pixelAspect": 1,
-                "clipIn": 1,
-                "clipOut": 1,
-                "frameStart": 1001,
-                "frameEnd": 1050,
-                "handleStart": 0,
-                "handleEnd": 0,
-                "startDate": "2021-01-01T00:00:00+00:00",
-                "endDate": "2021-01-01T00:00:00+00:00",
-                "description": "A very nice entity",
-                "applications": [],
-                "tools": []
-            },
-            "folder_types": [
-                {
-                    "name": "Asset",
-                    "icon": "folder",
-                    "original_name": "Asset"
-                }
-            ],
-            "task_types": [
-                {
-                    "name": "rendering",
-                    "shortName": "rendering",
-                    "icon": "",
-                    "original_name": "rendering"
-                }
-            ],
-            "linkTypes": [
-                {
-                    "name": "relationship|representation|representation",
-                    "link_type": "relationship",
-                    "input_type": "representation",
-                    "output_type": "representation",
-                    "data": {
-                        "color": "#73149F",
-                    }
-                }
-            ],
-            "statuses": [
-                {
-                    "name": "not_started",
-                    "shortName": "not_started",
-                    "state": "not_started",
-                    "icon": "",
-                    "color": "#cacaca",
-                    "original_name": "string"
-                }
-            ]
-        },
-        "library": False
+        "anatomy": project_anatomy,
+        "library": project_params["library"],
     }
     response = session.post(
         f"{server_url}/api/projects", json=project_data)
@@ -331,7 +492,7 @@ def project(  # noqa: PLR0914, PLR0915
     response = session.post(
         f"{server_url}/api/projects/{project_name}/folders", json={
             "name": folder_name,
-            "folderType": "Asset",
+            "folderType": folder_type,
         })
     assert response.status_code == STATUS_CREATED
     folder_id = response.json()["id"]
@@ -345,7 +506,7 @@ def project(  # noqa: PLR0914, PLR0915
     response = session.post(
         f"{server_url}/api/projects/{project_name}/tasks", json={
             "name": task_name,
-            "taskType": "rendering",
+            "taskType": task_type,
             "folderId": folder_entity["id"],
         })
     assert response.status_code == STATUS_CREATED
@@ -357,7 +518,7 @@ def project(  # noqa: PLR0914, PLR0915
         json={
             "name": product_name,
             "folderId": folder_entity["id"],
-            "productType": "render",
+            "productType": product_type,
         })
     assert response.status_code == STATUS_CREATED
     product_entity = response.json()
@@ -374,16 +535,21 @@ def project(  # noqa: PLR0914, PLR0915
 
     # Create a representations
     representations = []
-    for i in range(1, 5):
-        representation_name = f"exr_{i}"
+    publish_templates = project_data["anatomy"].get("templates", {}).get("publish", [])
+    assert publish_templates, "Project anatomy must define templates.publish"
+    root_entry = _first_work_root(project_data["anatomy"])
+    work_root = _work_root_path(root_entry)
+
+    for i in range(1, project_params["representation_count"] + 1):
+        representation_name = f"{project_params['representation_name_prefix']}_{i}"
         rep_data = create_representation(
             project_name, project_code, folder_name, task_name,
             product_name, version, version_entity["id"],
-            project_data["anatomy"]["templates"]["publish"],
-            project_data["anatomy"]["roots"][0]["windows"],
-            1001,
-            random.randint(1020, 1200),  # noqa: S311
-            representation_name
+            publish_templates,
+            work_root,
+            project_params["frame_start"],
+            random.randint(project_params["frame_end_min"], project_params["frame_end_max"]),
+            representation_name,
         )
 
         response = session.post(
@@ -397,39 +563,28 @@ def project(  # noqa: PLR0914, PLR0915
         representations.append(IdNamePair(
             name=representation_name, id=response.json()["id"]))
 
-    # link first representation to the second one
-    response = session.post(
-        f"{server_url}/api/projects/{project_name}/links",
-        json={
-            "input": representations[0].id,
-            "output": representations[1].id,
-            "name": "relationship_2",
-            "link": "relationship|representation|representation",
-            "linkType": "relationship|representation|representation",
-            "data": {}
-        }
-    )
-    assert response.status_code == STATUS_OK, response.json()
-    links = [response.json()["id"]]
-    # link second representation to the third one
-    response = session.post(
-        f"{server_url}/api/projects/{project_name}/links",
-        json={
-            "input": representations[2].id,
-            "output": representations[3].id,
-            "name": "relationship_1",
-            "link": "relationship|representation|representation",
-            "linkType": "relationship|representation|representation",
-            "data": {}
-        }
-    )
-    assert response.status_code == STATUS_OK, response.json()
-    links.append(response.json()["id"])
+    links = []
+    for input_idx, output_idx, link_name in project_params["link_pairs"]:
+        if input_idx >= len(representations) or output_idx >= len(representations):
+            continue
+        response = session.post(
+            f"{server_url}/api/projects/{project_name}/links",
+            json={
+                "input": representations[input_idx].id,
+                "output": representations[output_idx].id,
+                "name": link_name,
+                "link": "relationship|representation|representation",
+                "linkType": "relationship|representation|representation",
+                "data": {}
+            }
+        )
+        assert response.status_code == STATUS_OK, response.json()
+        links.append(response.json()["id"])
 
     yield ProjectInfo(
         project_name=project_name,
         project_code=project_code,
-        project_root_folders=project_data["anatomy"]["roots"][0],
+        project_root_folders=root_entry,
         folder=IdNamePair(name=folder_name, id=folder_entity["id"]),
         folder_entity=folder_entity,
         task=IdNamePair(name=task_name, id=task_entity["id"]),
@@ -454,11 +609,12 @@ def empty_project(  # noqa: PLR0913, PLR0917
     request: pytest.FixtureRequest,
     printer: Any,  # noqa: ANN401 (fixture)
     ayon_connection_env: tuple[str, str],
+    project_anatomy: dict[str, Any],
     project_name: Optional[str] = None,
     project_code: Optional[str] = None,
-    folder_types: list[str] = ("Asset", "Episode", "Sequence", "Shot"),
-    task_types: list[str] = ("rendering",),
-    statuses: list[str] = ("not_started",),
+    folder_types: tuple[str, ...] = ("Asset", "Episode", "Sequence", "Shot"),
+    task_types: tuple[str] = ("rendering",),
+    statuses: tuple[str] = ("not_started",),
 ) -> Generator[ProjectInfo, None, None]:
     """Set up an empty project and yield the project info.
 
@@ -469,6 +625,7 @@ def empty_project(  # noqa: PLR0913, PLR0917
         request: The pytest request fixture.
         printer: The printer fixture.
         ayon_connection_env: The AYON connection environment fixture.
+        project_anatomy: The project anatomy fixture.
         project_name: The project name. If None, a random
             name will be generated.
         project_code: The project code. If None, a random
@@ -500,110 +657,39 @@ def empty_project(  # noqa: PLR0913, PLR0917
     session = requests.Session()
     session.headers.update({"x-api-key": api_key})
 
-    project_data = {
+
+    project_anatomy["folder_types"] = [
+        {
+            "name": folder_type.capitalize(),
+            "icon": "folder",
+            "original_name": folder_type.capitalize(),
+        } for folder_type in values["folder_types"]
+    ]
+
+    project_anatomy["task_types"] = [
+        {
+            "name": task_type.lower(),
+            "shortName": task_type.lower(),
+            "icon": "",
+            "original_name": task_type.lower(),
+        } for task_type in values["task_types"]
+    ]
+
+    project_anatomy["statuses"] = [
+        {
+            "name": status.lower(),
+            "shortName": status.lower(),
+            "state": status.lower(),
+            "icon": "",
+            "color": "#cacaca",
+            "original_name": "string"
+        } for status in values["statuses"]
+    ]
+
+    project_data: dict[str, Any] = {
         "name": values["project_name"],
         "code": values["project_code"],
-        "anatomy": {
-            "roots": [
-                {
-                    "name": "work",
-                    "windows": "C:/projects",
-                    "linux": "/mnt/share/projects",
-                    "darwin": "/Volumes/projects"
-                }
-            ],
-            "templates": {
-                "version_padding": 3,
-                "version": "v{version:0>{@version_padding}}",
-                "frame_padding": 4,
-                "frame": "{frame:0>{@frame_padding}}",
-                "work": [
-                    {
-                        "name": "default",
-                        "directory": "{root[work]}/{project[name]}/"
-                                     "{hierarchy}/{folder[name]}/"
-                                     "work/{task[name]}",
-                        "file": "{project[code]}_{folder[name]}"
-                                "_{task[name]}_{@version}<_{comment}>.{ext}"
-                    }
-                ],
-                "publish": [
-                    {
-                        "name": "default",
-                        "directory": "{root[work]}/{project[name]}/"
-                                     "{hierarchy}/{folder[name]}/"
-                                     "publish/{product[type]}/"
-                                     "{product[name]}/v{version:0>3}",
-                        "file": "{project[code]}_{folder[name]}_"
-                                "{product[name]}_v{version:0>3}<_{output}>"
-                                "<.{frame:0>4}><_{udim}>.{ext}"
-                    }
-                ],
-                "hero": [
-                    {
-                        "name": "default",
-                        "directory": "{root[work]}/{project[name]}/"
-                                     "{hierarchy}/{folder[name]}/publish/"
-                                     "{product[type]}/{product[name]}/hero",
-                        "file": "{project[code]}_{folder[name]}_"
-                                "{task[name]}_hero<_{comment}>.{ext}"
-                    }
-                ],
-            },
-            "attributes": {
-                "fps": 25,
-                "resolutionWidth": 1920,
-                "resolutionHeight": 1080,
-                "pixelAspect": 1,
-                "clipIn": 1,
-                "clipOut": 1,
-                "frameStart": 1001,
-                "frameEnd": 1050,
-                "handleStart": 0,
-                "handleEnd": 0,
-                "startDate": "2021-01-01T00:00:00+00:00",
-                "endDate": "2021-01-01T00:00:00+00:00",
-                "description": "A very nice entity",
-                "applications": [],
-                "tools": []
-            },
-            "folder_types": [
-                {
-                    "name": folder_type.capitalize(),
-                    "icon": "folder",
-                    "original_name": folder_type.capitalize(),
-                } for folder_type in values["folder_types"]
-            ],
-            "task_types": [
-                {
-                    "name": task_type.lower(),
-                    "shortName": task_type.lower(),
-                    "icon": "",
-                    "original_name": task_type.lower(),
-                } for task_type in values["task_types"]
-            ],
-            "linkTypes": [
-                {
-                    "name": "relationship|representation|representation",
-                    "link_type": "relationship",
-                    "input_type": "representation",
-                    "output_type": "representation",
-                    "data": {
-                        "color": "#73149F",
-                    }
-                }
-            ],
-            "statuses": [
-                {
-                    "name": status.lower(),
-                    "shortName": status.lower(),
-                    "state": status.lower(),
-                    "icon": "",
-                    "color": "#cacaca",
-                    "original_name": "string"
-                } for status in values["statuses"]
-            ]
-        },
+        "anatomy": project_anatomy,
         "library": False
     }
     response = session.post(

--- a/pytest_ayon/utils.py
+++ b/pytest_ayon/utils.py
@@ -52,7 +52,7 @@ def create_file_list(  # noqa: PLR0913, PLR0917
                 f"{{root[work]}}/{project_name}/{asset_name}/publish"
                 f"/render/v{version:03d}/{file_name}"),
             "size": random.randint(100000, 1000000),  # noqa: S311
-            "hash": hashlib.md5(file_name).hexdigest(),  # noqa: S324
+            "hash": hashlib.md5(file_name.encode()).hexdigest(),  # noqa: S324
             "hashType": "md5"
         })
     return files


### PR DESCRIPTION
## Changelog Description
Change how anatomy is used in fixtures. Ability to get it from the server, either the builtin or primary preset.

## Additional review information
This is one of many steps to make the tests more parametrized.

## Testing notes:
This might break tests unexpectedly. You can test it with your current repo - add it to `pyproject.toml` like this:

```toml
...
dependencies = [
    ...
    "pytest-ayon"
]


[tool.uv.sources]
pytest-ayon = { git = "https://github.com/ynput/pytest-ayon.git", rev = "enhancement/parametrized-anatomy" }
```

> [!NOTE]
> This might replace #3 